### PR TITLE
Remove climb tag from OSM normalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### 0.2.10
+- Removed `climb` tag generation from OSM normalizer
+
 ### 0.2.9
 - Retain existing `incline` and `climb` tags when converting OSW to OSM
 - Add `climb` tag when missing and `incline` is provided

--- a/src/osm_osw_reformatter/serializer/osm/osm_normalizer.py
+++ b/src/osm_osw_reformatter/serializer/osm/osm_normalizer.py
@@ -45,18 +45,14 @@ class OSMNormalizer(ogr2osm.TranslationBase):
             tags.pop('foot', '')
 
         # OSW fields with similar OSM field names
+        tags.pop('climb', '')
         if 'incline' in tags:
             try:
                 incline_val = float(str(tags['incline']).rstrip('%'))
             except (ValueError, TypeError):
-                incline_val = None
+                pass
             else:
                 tags['incline'] = str(incline_val)
-                if 'climb' not in tags:
-                    if incline_val > 0:
-                        tags['climb'] = 'up'
-                    elif incline_val < 0:
-                        tags['climb'] = 'down'
 
         self._check_datatypes(tags)
 

--- a/tests/unit_tests/test_osw2osm/test_osw2osm.py
+++ b/tests/unit_tests/test_osw2osm/test_osw2osm.py
@@ -65,7 +65,7 @@ class TestOSW2OSM(unittest.IsolatedAsyncioTestCase):
         result = osw2osm.convert()
         self.assertFalse(result.status)
 
-    def test_generated_file_contains_climb_tag(self):
+    def test_generated_file_does_not_contain_climb_tag(self):
         zip_file = TEST_DATA_WITH_INCLINE_ZIP_FILE
         osw2osm = OSW2OSM(zip_file_path=zip_file, workdir=OUTPUT_DIR, prefix='test')
         result = osw2osm.convert()
@@ -73,7 +73,7 @@ class TestOSW2OSM(unittest.IsolatedAsyncioTestCase):
 
         tree = ET.parse(xml_file_path)
         root = tree.getroot()
-        self.assertGreater(len(root.findall(".//tag[@k='climb']")), 0)
+        self.assertEqual(len(root.findall(".//tag[@k='climb']")), 0)
 
         os.remove(result.generated_files)
 
@@ -89,7 +89,7 @@ class TestOSW2OSM(unittest.IsolatedAsyncioTestCase):
 
         os.remove(result.generated_files)
 
-    def test_incline_tags_have_climb(self):
+    def test_incline_tags_do_not_have_climb(self):
         zip_file = TEST_DATA_WITH_INCLINE_ZIP_FILE
         osw2osm = OSW2OSM(zip_file_path=zip_file, workdir=OUTPUT_DIR, prefix='test')
         result = osw2osm.convert()
@@ -101,7 +101,7 @@ class TestOSW2OSM(unittest.IsolatedAsyncioTestCase):
         for element in root.findall('.//way') + root.findall('.//node') + root.findall('.//relation'):
             tags = {tag.get('k'): tag.get('v') for tag in element.findall('tag')}
             if 'incline' in tags and float(tags.get('incline', 0) or 0) != 0:
-                self.assertIn('climb', tags)
+                self.assertNotIn('climb', tags)
 
         os.remove(result.generated_files)
 

--- a/tests/unit_tests/test_serializer/test_osm_normalizer.py
+++ b/tests/unit_tests/test_serializer/test_osm_normalizer.py
@@ -55,34 +55,34 @@ class TestOSMNormalizeInclineField(unittest.TestCase):
     def setUp(self):
         self.normalizer = OSMNormalizer()
 
-    def test_retains_existing_incline_and_climb(self):
+    def test_removes_existing_climb_and_retains_incline(self):
         tags = {"highway": "footway", "incline": 0.014, "climb": "up"}
         normalizer = self.normalizer.filter_tags(tags)
         self.assertEqual(normalizer["incline"], "0.014")
-        self.assertEqual(normalizer["climb"], "up")
+        self.assertNotIn("climb", normalizer)
 
-    def test_derives_climb_from_positive_incline(self):
+    def test_does_not_add_climb_from_positive_incline(self):
         tags = {"highway": "footway", "incline": 0.014}
         normalizer = self.normalizer.filter_tags(tags)
-        self.assertEqual(normalizer["climb"], "up")
+        self.assertNotIn("climb", normalizer)
         self.assertEqual(normalizer["incline"], "0.014")
 
-    def test_derives_climb_from_negative_incline(self):
+    def test_does_not_add_climb_from_negative_incline(self):
         tags = {"highway": "footway", "incline": -0.014}
         normalizer = self.normalizer.filter_tags(tags)
-        self.assertEqual(normalizer["climb"], "down")
+        self.assertNotIn("climb", normalizer)
         self.assertEqual(normalizer["incline"], "-0.014")
 
-    def test_does_not_derive_climb_from_zero_incline(self):
+    def test_does_not_add_climb_from_zero_incline(self):
         tags = {"highway": "footway", "incline": 0}
         normalizer = self.normalizer.filter_tags(tags)
         self.assertEqual(normalizer["incline"], "0.0")
         self.assertNotIn("climb", normalizer)
 
-    def test_retains_climb_without_incline(self):
+    def test_removes_climb_without_incline(self):
         tags = {"highway": "footway", "climb": "down"}
         normalizer = self.normalizer.filter_tags(tags)
-        self.assertEqual(normalizer["climb"], "down")
+        self.assertNotIn("climb", normalizer)
         self.assertNotIn("incline", normalizer)
 
     def test_retains_non_numeric_incline_without_climb(self):


### PR DESCRIPTION
## Summary
- drop automatic `climb` tag handling in `OSMNormalizer`
- update tests and changelog for removed `climb` tag

## Testing
- `pytest -q` *(fails: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68be9c372f408327ba745cb682e1d519