### PR TITLE
Add OSM compliance validation test using python-osw-validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ shapely~=2.0.2
 pyproj~=3.6.1
 coverage~=7.5.1
 ogr2osm==1.2.0
+python-osw-validation==0.2.13

--- a/tests/unit_tests/test_osm_compliance/test_osm_compliance.py
+++ b/tests/unit_tests/test_osm_compliance/test_osm_compliance.py
@@ -1,0 +1,41 @@
+import os
+import zipfile
+import unittest
+import subprocess
+import shutil
+
+from src.osm_osw_reformatter.osw2osm.osw2osm import OSW2OSM
+from src.osm_osw_reformatter import Formatter
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(ROOT_DIR)), 'output')
+TEST_DATA_WITH_INCLINE_ZIP_FILE = os.path.join(ROOT_DIR, 'test_files/dataset_with_incline.zip')
+
+
+class TestOSMCompliance(unittest.IsolatedAsyncioTestCase):
+    async def test_output_is_osm_compliant(self):
+        osw2osm = OSW2OSM(zip_file_path=TEST_DATA_WITH_INCLINE_ZIP_FILE, workdir=OUTPUT_DIR, prefix='compliance')
+        result = osw2osm.convert()
+        osm_file = result.generated_files
+
+        formatter = Formatter(workdir=OUTPUT_DIR, file_path=osm_file, prefix='compliance')
+        res = await formatter.osm2osw()
+        osw_files = res.generated_files
+
+        zip_path = os.path.join(OUTPUT_DIR, 'compliance_osw.zip')
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            for f in osw_files:
+                zipf.write(f, os.path.basename(f))
+
+        validator = shutil.which('osw-validate')
+        if validator is None:
+            self.skipTest('python-osw-validation not installed')
+        proc = subprocess.run([validator, zip_path], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, f"Validator output: {proc.stdout}\n{proc.stderr}")
+
+        os.remove(osm_file)
+        for f in osw_files:
+            os.remove(f)
+        os.remove(zip_path)
+        formatter.cleanup()
+

--- a/tests/unit_tests/test_osm_compliance/test_osm_compliance.py
+++ b/tests/unit_tests/test_osm_compliance/test_osm_compliance.py
@@ -1,8 +1,7 @@
 import os
 import zipfile
 import unittest
-import subprocess
-import shutil
+from python_osw_validation import OSWValidation
 
 from src.osm_osw_reformatter.osw2osm.osw2osm import OSW2OSM
 from src.osm_osw_reformatter import Formatter
@@ -27,15 +26,12 @@ class TestOSMCompliance(unittest.IsolatedAsyncioTestCase):
             for f in osw_files:
                 zipf.write(f, os.path.basename(f))
 
-        validator = shutil.which('osw-validate')
-        if validator is None:
-            self.skipTest('python-osw-validation not installed')
-        proc = subprocess.run([validator, zip_path], capture_output=True, text=True)
-        self.assertEqual(proc.returncode, 0, f"Validator output: {proc.stdout}\n{proc.stderr}")
+        validator = OSWValidation(zipfile_path=zip_path)
+        result = validator.validate()
+        self.assertEqual(len(result.issues), 0, f'OSW Validation errors: {result.errors}')
 
         os.remove(osm_file)
         for f in osw_files:
             os.remove(f)
         os.remove(zip_path)
         formatter.cleanup()
-


### PR DESCRIPTION
## Summary
- add python-osw-validation dependency
- add unit test validating OSW zip via osw-validate tool

## Testing
- `python -m unittest tests.unit_tests.test_osm_compliance.test_osm_compliance` *(fails: ModuleNotFoundError: No module named 'pyproj')*


------
https://chatgpt.com/codex/tasks/task_e_68bea2ca6f808327bd7091d0d72a036b